### PR TITLE
feat: add metadata storage

### DIFF
--- a/include/aws/store/common/slices.hpp
+++ b/include/aws/store/common/slices.hpp
@@ -14,7 +14,7 @@ class BorrowedSlice {
     const uint32_t _size;
 
   public:
-    BorrowedSlice() : _data(nullptr), _size(0U) {};
+    BorrowedSlice() : _data(nullptr), _size(0U){};
     BorrowedSlice(const void *data, const size_t size) : _data(data), _size(static_cast<uint32_t>(size)) {
         // coverity[misra_cpp_2008_rule_5_2_12_violation] false positive
         assert(size <= UINT32_MAX);

--- a/include/aws/store/filesystem/filesystem.hpp
+++ b/include/aws/store/filesystem/filesystem.hpp
@@ -34,7 +34,7 @@ class FileLike {
 
     virtual void sync() = 0;
 
-    virtual FileError truncate(uint32_t) = 0;
+    virtual FileError truncate(uint64_t) = 0;
 
     FileLike(FileLike &) = delete;
 

--- a/include/aws/store/filesystem/posixFileSystem.hpp
+++ b/include/aws/store/filesystem/posixFileSystem.hpp
@@ -116,7 +116,7 @@ class PosixFileLike : public FileLike {
         aws::store::filesystem::sync(fileno(_f));
     }
 
-    virtual FileError truncate(const uint32_t max) override {
+    virtual FileError truncate(const uint64_t max) override {
         // Flush buffers before truncating since truncation is operating on the FD directly rather than the file
         // stream
         std::ignore = flush();
@@ -213,7 +213,7 @@ class PosixUnbufferedFileLike : public FileLike {
         aws::store::filesystem::sync(_f);
     }
 
-    virtual FileError truncate(const uint32_t max) override {
+    virtual FileError truncate(const uint64_t max) override {
         if (ftruncate(_f, static_cast<off_t>(max)) != 0) {
             return errnoToFileError(errno);
         }

--- a/include/aws/store/stream/memoryStream.hpp
+++ b/include/aws/store/stream/memoryStream.hpp
@@ -26,10 +26,11 @@ class __attribute__((visibility("default"))) MemoryStream : public StreamInterfa
   public:
     static std::shared_ptr<MemoryStream> openOrCreate(StreamOptions &&) noexcept;
 
-    common::Expected<uint64_t, StreamError> append(const common::BorrowedSlice,
+    common::Expected<uint64_t, StreamError> append(const common::BorrowedSlice, const common::BorrowedSlice,
                                                    const AppendOptions &) noexcept override;
 
-    common::Expected<uint64_t, StreamError> append(common::OwnedSlice &&, const AppendOptions &) noexcept override;
+    common::Expected<uint64_t, StreamError> append(common::OwnedSlice &&, common::OwnedSlice &&,
+                                                   const AppendOptions &) noexcept override;
 
     common::Expected<OwnedRecord, StreamError> read(const uint64_t sequence_number,
                                                     const ReadOptions &) const noexcept override;

--- a/include/aws/store/stream/stream.hpp
+++ b/include/aws/store/stream/stream.hpp
@@ -25,13 +25,14 @@ namespace stream __attribute__((visibility("default"))) {
         common::OwnedSlice data{};
         int64_t timestamp{};
         uint64_t sequence_number{};
+        common::OwnedSlice metadata{};
 
         OwnedRecord() = default;
 
         // coverity[autosar_cpp14_a15_4_3_violation] false positive, all implementations are noexcept
         // coverity[misra_cpp_2008_rule_15_4_1_violation] false positive, implementation is noexcept
         OwnedRecord(common::OwnedSlice &&idata, const int64_t itimestamp, const uint64_t isequence_number,
-                    const uint32_t ioffset) noexcept;
+                    const uint32_t ioffset, common::OwnedSlice &&imetadata) noexcept;
     };
 
     enum class StreamErrorCode : std::uint8_t {
@@ -163,7 +164,7 @@ namespace stream __attribute__((visibility("default"))) {
          *
          * @return the sequence number of the record appended.
          */
-        virtual common::Expected<uint64_t, StreamError> append(const common::BorrowedSlice,
+        virtual common::Expected<uint64_t, StreamError> append(const common::BorrowedSlice, const common::BorrowedSlice,
                                                                const AppendOptions &) noexcept = 0;
 
         /**
@@ -171,7 +172,7 @@ namespace stream __attribute__((visibility("default"))) {
          *
          * @return the sequence number of the record appended.
          */
-        virtual common::Expected<uint64_t, StreamError> append(common::OwnedSlice &&,
+        virtual common::Expected<uint64_t, StreamError> append(common::OwnedSlice &&, common::OwnedSlice &&,
                                                                const AppendOptions &) noexcept = 0;
 
         /**

--- a/src/stream/stream.cpp
+++ b/src/stream/stream.cpp
@@ -91,8 +91,9 @@ int64_t timestamp() noexcept {
 }
 
 OwnedRecord::OwnedRecord(common::OwnedSlice &&idata, const int64_t itimestamp, const uint64_t isequence_number,
-                         const uint32_t ioffset) noexcept
-    : offset(ioffset), data(std::move(idata)), timestamp(itimestamp), sequence_number(isequence_number) {
+                         const uint32_t ioffset, common::OwnedSlice &&imetadata) noexcept
+    : offset(ioffset), data(std::move(idata)), timestamp(itimestamp), sequence_number(isequence_number),
+      metadata(std::move(imetadata)) {
 }
 
 CheckpointableOwnedRecord::CheckpointableOwnedRecord(OwnedRecord &&o,

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -167,7 +167,7 @@ class SpyFileLike : public store::filesystem::FileLike {
         _real->sync();
     }
 
-    filesystem::FileError truncate(const uint32_t s) override {
+    filesystem::FileError truncate(const uint64_t s) override {
         if (!_mocks.empty() && _mocks.front().first == "truncate") {
             const auto mock = _mocks.front();
             _mocks.pop_front();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [ ] TODO unit tests

Add support for metadata of arbitrary size in a stream record.  

A new metadata field as been added in the record header:
```
struct LogEntryHeader {
    int32_t metadata_length_bytes;
    ...
}
```

And the payload structure has been modified to be:
```
<header><metadata><data>
```

## Motivation

Applications may not be able to (easily/efficiently) read the contents of stored data if they are serialized/encrypted/compressed, etc.  Metadata can be used to drive application logic without having to crack into the data itself.

## Implications

* Record header has been increased to 40 bytes. This applies even if metadata is not being used.
* Header `byte_position` has been increased from int32 to int64, since the addition of metadata length can make total length > int32

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
