### PR TITLE
fix: remove bugprone-suspicious-include check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,6 @@ Checks: >
     bugprone-string-literal-with-embedded-nul,
     bugprone-stringview-nullptr,
     bugprone-suspicious-enum-usage,
-    bugprone-suspicious-include,
     bugprone-suspicious-memory-comparison,
     bugprone-suspicious-memset-usage,
     bugprone-suspicious-missing-comma,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Unable to build this project when using `CMAKE_INSTALL_PREFIX`, as it trips the following warning (treated as error)

```
#8 334.2 /tmp/deps-native/device-storelibrary-cpp/build/CMakeFiles/kv.dir/Unity/unity_0_cxx.cxx:3:11: error: suspicious #include of file with '.cpp' extension [bugprone-suspicious-include,-warnings-as-errors]
#8 334.2 #include "/tmp/deps-native/device-storelibrary-cpp/src/kv/kv.cpp"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
